### PR TITLE
Use mount module instead of lineinfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,26 @@ An NFS server
 Role Variables
 --------------
 
+Old method **nfs_mount**:
+
 For example:
 <pre>
 nfs_mount: |
   10.2.1.5:/scratch /scratch                nfs4 defaults 0 0
   10.2.1.5:/home    /home                   nfs4 defaults 0 0
 </pre>
+
+New method **nfs_mounts**
+
+This only works if nfs_mount variable is not defined
+
+<pre>
+nfs_mounts:
+ - { fstype: "nfs4", name: "/home", src: "{{ nfs_mount_addr }}:/home", state: "mounted", opts: "defaults" }
+ - { name: "/scratch", src: "{{ nfs_mount_addr }}:/scratch" }
+</pre>
+
+Notice how fstype defaults to "nfs4", state defaults to "mounted" and opts defaults to "defaults".
 
 Dependencies
 ------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,8 +1,16 @@
 ---
 # defaults file for ansible-role-nfs_mount/
+## old method which uses the ansible lineinfile module to modify fstab
 # #Define something like this:
 #
 # nfs_mount: |
 #  10.2.1.5:/scratch /scratch                nfs4 defaults 0 0
 #  10.2.1.5:/home    /home                   nfs4 defaults 0 0
 #
+
+## new method which uses the ansible mount module
+nfs_mounts:
+  - {}
+# - { fstype: "nfs4", name: "/home", src: "{{ nfs_mount_addr }}:/home", state: "mounted", opts: "defaults" }
+# - { name: "/scratch", src: "{{ nfs_mount_addr }}:/scratch" }
+

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,21 +7,36 @@
 - name: Creates /scratch dir (if it doesn't exist)
   file: path=/scratch state=directory mode=0755
 
-- name: cleanning previous entries on /etc/fstab
+## old method using lineinfile and editing fstab 
+
+- name: lineinfile cleaning previous entries on /etc/fstab
   lineinfile: backup=yes dest=/etc/fstab regexp=".*\home\b.*$" state=absent
   when: nfs_mount is defined
 
-- name: cleanning previous entries on /etc/fstab
+- name: lineinfile cleaning previous entries on /etc/fstab
   lineinfile: backup=yes dest=/etc/fstab regexp=^{{ nfs_mount_addr }} state=absent
   when: nfs_mount is defined
 
-- name: populate /etc/fstab file with NFS mount points
+- name: lineinfile populate /etc/fstab file with NFS mount points
   lineinfile: dest=/etc/fstab line="{{ nfs_mount }}" state=present
   when: nfs_mount is defined
 
-- name: cleaning blank lines on /etc/fstab
+- name: lineinfile cleaning blank lines on /etc/fstab
   lineinfile: backup=no dest=/etc/fstab regexp="^\s*$" state=absent
   when: nfs_mount is defined
 
-- name: reloading mount points
+- name: reloading mount points with mount -a
   command: /usr/bin/mount -a
+  when: nfs_mount is defined
+
+## new method with the mount module
+
+- name: add mountpoints if nfs_mounts is defined and nfs_mount is not
+  mount:
+        fstype="{{ item.fstype | default('nfs4') }}"
+        name="{{ item.name }}"  
+        src="{{ item.src }}"  
+        state="{{ item.state | default('mounted') }}"
+        opts="{{ item.opts | default('defaults') }}"
+  with_items: "{{ nfs_mounts }}"
+  when: nfs_mounts is defined and nfs_mounts.0 != {} and nfs_mount is not defined

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,9 +3,11 @@
 
 - name: Creates /home dir (if it doesn't exist)
   file: path=/home state=directory mode=0755
+  when: nfs_mount is defined
 
 - name: Creates /scratch dir (if it doesn't exist)
   file: path=/scratch state=directory mode=0755
+  when: nfs_mount is defined
 
 ## old method using lineinfile and editing fstab 
 
@@ -30,6 +32,10 @@
   when: nfs_mount is defined
 
 ## new method with the mount module
+
+- name: Create directories (if they do not exist) if nfs_mounts is defined
+  file: path={{ item.name }} state=directory mode=0755
+  when: nfs_mounts is defined and nfs_mounts.0 != {} and nfs_mount is not defined
 
 - name: add mountpoints if nfs_mounts is defined and nfs_mount is not
   mount:


### PR DESCRIPTION
Possible fix for #2 

Keeping the defaults to the old method.
For FGCI to change to using the new method by default we'd have to ensure that the nfs_mounts variable is defined for all the clusters.
