### PR TITLE
old-style nfs_mount is still used, stop it backupping fstab

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,7 +15,7 @@
   lineinfile:
        backup: no
        dest: /etc/fstab
-       regexp: =".*\home\b.*$"
+       regexp: ".*\home\b.*$"
        state: absent
   when: nfs_mount is defined
 
@@ -38,7 +38,8 @@
 - name: (DEPRECATED) lineinfile cleaning blank lines on /etc/fstab
   lineinfile: 
        dest: /etc/fstab
-       regexp: "^\s*$" state=absent
+       regexp: "^\s*$"
+       state: absent
        backup: no
   when: nfs_mount is defined
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,11 +2,17 @@
 # tasks file for ansible-role-nfs_mount/
 
 - name: (DEPRECATED) Creates /home dir (if it doesn't exist)
-  file: path=/home state=directory mode=0755
+  file: 
+     path: /home
+     state: directory
+     mode: 0755
   when: nfs_mount is defined
 
 - name: (DEPRECATED) Creates /scratch dir (if it doesn't exist)
-  file: path=/scratch state=directory mode=0755
+  file: 
+     path: "/scratch"
+     state: directory
+     mode: 0755
   when: nfs_mount is defined
 
 ## old method using lineinfile and editing fstab 
@@ -23,7 +29,7 @@
   lineinfile: 
        backup: no
        dest: /etc/fstab
-       regexp: ^{{ nfs_mount_addr }}
+       regexp: "^{{ nfs_mount_addr }}"
        state: absent
   when: nfs_mount is defined
 
@@ -51,7 +57,7 @@
 
 - name: Create directories (if they do not exist) if nfs_mounts is defined
   file: 
-     path: {{ item.name }}
+     path: "{{ item.name }}"
      state: directory
      mode: "{{ item.dirmode | default ('0755') }}"
   with_items: "{{ nfs_mounts }}"
@@ -69,12 +75,15 @@
 
 - name: find backed up fstab files
   find: 
-      paths=/etc patterns="fstab.*~"
+      paths: "/etc" 
+      patterns: "fstab.*~"
   register: nfs_backup_files
   changed_when: False
   check_mode: no
 
-- debug: var=nfs_backup_files verbosity=1
+- debug:
+     var: nfs_backup_files
+     verbosity: 1
 
 - name: cleaning fstab backup files
   file: 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,7 +15,7 @@
   lineinfile:
        backup: no
        dest: /etc/fstab
-       regexp: ".*\home\b.*$"
+       regexp: ".*/home\b.*$"
        state: absent
   when: nfs_mount is defined
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,7 +38,7 @@
 - name: (DEPRECATED) lineinfile cleaning blank lines on /etc/fstab
   lineinfile: 
        dest: /etc/fstab
-       regexp: "^\s*$"
+       regexp: "^\\s*$"
        state: absent
        backup: no
   when: nfs_mount is defined

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,19 +12,34 @@
 ## old method using lineinfile and editing fstab 
 
 - name: (DEPRECATED) lineinfile cleaning previous entries on /etc/fstab
-  lineinfile: backup=yes dest=/etc/fstab regexp=".*\home\b.*$" state=absent
+  lineinfile:
+       backup: no
+       dest: /etc/fstab
+       regexp: =".*\home\b.*$"
+       state: absent
   when: nfs_mount is defined
 
 - name: (DEPRECATED) lineinfile cleaning previous entries on /etc/fstab
-  lineinfile: backup=yes dest=/etc/fstab regexp=^{{ nfs_mount_addr }} state=absent
+  lineinfile: 
+       backup: no
+       dest: /etc/fstab
+       regexp: ^{{ nfs_mount_addr }}
+       state: absent
   when: nfs_mount is defined
 
 - name: (DEPRECATED) lineinfile populate /etc/fstab file with NFS mount points
-  lineinfile: dest=/etc/fstab line="{{ nfs_mount }}" state=present
+  lineinfile: 
+       dest: /etc/fstab
+       line: "{{ nfs_mount }}" 
+       state: present
+       backup: no
   when: nfs_mount is defined
 
 - name: (DEPRECATED) lineinfile cleaning blank lines on /etc/fstab
-  lineinfile: backup=no dest=/etc/fstab regexp="^\s*$" state=absent
+  lineinfile: 
+       dest: /etc/fstab
+       regexp: "^\s*$" state=absent
+       backup: no
   when: nfs_mount is defined
 
 - name: (DEPRECATED) reloading mount points with mount -a
@@ -34,22 +49,26 @@
 ## new method with the mount module
 
 - name: Create directories (if they do not exist) if nfs_mounts is defined
-  file: path={{ item.name }} state=directory mode="{{ item.dirmode | default ('0755') }}"
+  file: 
+     path: {{ item.name }}
+     state: directory
+     mode: "{{ item.dirmode | default ('0755') }}"
   with_items: "{{ nfs_mounts }}"
   when: nfs_mounts is defined and nfs_mounts.0 != {} and nfs_mount is not defined
 
 - name: add mountpoints if nfs_mounts is defined and nfs_mount is not
   mount:
-        fstype="{{ item.fstype | default('nfs4') }}"
-        name="{{ item.name }}"  
-        src="{{ item.src }}"  
-        state="{{ item.state | default('mounted') }}"
-        opts="{{ item.opts | default('defaults') }}"
+        fstype: "{{ item.fstype | default('nfs4') }}"
+        name: "{{ item.name }}"  
+        src: "{{ item.src }}"  
+        state: "{{ item.state | default('mounted') }}"
+        opts: "{{ item.opts | default('defaults') }}"
   with_items: "{{ nfs_mounts }}"
   when: nfs_mounts is defined and nfs_mounts.0 != {} and nfs_mount is not defined
 
 - name: find backed up fstab files
-  find: paths=/etc patterns="fstab.201*"
+  find: 
+      paths=/etc patterns="fstab.*~"
   register: nfs_backup_files
   changed_when: False
   check_mode: no
@@ -57,6 +76,8 @@
 - debug: var=nfs_backup_files verbosity=1
 
 - name: cleaning fstab backup files
-  file: path={{ item.path }} state=absent
+  file: 
+     path: "{{ item.path }}"
+     state: absent
   with_items: '{{ nfs_backup_files.files }}'
   when: clean_fstab_backups and nfs_backup_files.matched != 0

--- a/tests/test-in-docker-image.sh
+++ b/tests/test-in-docker-image.sh
@@ -126,6 +126,7 @@ function show_fstab() {
 	echo %%%%% fstab follows
 	cat /etc/fstab
 	echo %%%%% fstab ends
+}
 
 set -e
 function main(){

--- a/tests/test-in-docker-image.sh
+++ b/tests/test-in-docker-image.sh
@@ -122,6 +122,10 @@ function extra_tests(){
     ${APACHE_CTL} configtest || (echo "php --version was failed" && exit 100 )
 }
 
+function show_fstab() {
+	echo %%%%% fstab follows
+	cat /etc/fstab
+	echo %%%%% fstab ends
 
 set -e
 function main(){
@@ -135,6 +139,7 @@ function main(){
     test_playbook
     test_playbook_check
 #    extra_tests
+    show_fstab
 
 }
 


### PR DESCRIPTION
thebe still used old-style, and it's nodes are full of /etc/fstab.<junk>~ files.

- Set backup: no for all lineinfiles
- Set pattern of old backups to delete to actually match what is getting created.

