### PR TITLE
Remove deprecated method

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,17 +12,6 @@ An NFS server
 Role Variables
 --------------
 
-Old method **nfs_mount**:
-
-For example:
-<pre>
-nfs_mount: |
-  10.2.1.5:/scratch /scratch                nfs4 defaults 0 0
-  10.2.1.5:/home    /home                   nfs4 defaults 0 0
-</pre>
-
-New method **nfs_mounts**
-
 This only works if nfs_mount variable is not defined
 
 <pre>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://travis-ci.org/CSCfi/ansible-role-nfs_mount.svg)](https://travis-ci.org/CSCfi/ansible-role-nfs_mount)
-ansible-role-nfs_mount
+ansible-role-nfs\_mount
 =========
 
 Mounts NFS
@@ -12,8 +12,6 @@ An NFS server
 Role Variables
 --------------
 
-This only works if nfs_mount variable is not defined
-
 <pre>
 nfs_mounts:
  - { fstype: "nfs4", name: "/home", src: "{{ nfs_mount_addr }}:/home", state: "mounted", opts: "defaults" }
@@ -25,7 +23,7 @@ Notice how fstype defaults to "nfs4", state defaults to "mounted" and opts defau
 Dependencies
 ------------
 
-A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set for other roles, or variables that are used from other roles.
+None
 
 Example Playbook
 ----------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,18 +1,6 @@
 ---
 # defaults file for ansible-role-nfs_mount/
-## old method which uses the ansible lineinfile module to modify fstab
-# #Define something like this:
-#
-# nfs_mount: |
-#  10.2.1.5:/scratch /scratch                nfs4 defaults 0 0
-#  10.2.1.5:/home    /home                   nfs4 defaults 0 0
-#
-
-## new method which uses the ansible mount module
 nfs_mounts:
   - {}
 # - { fstype: "nfs4", name: "/home", src: "{{ nfs_mount_addr }}:/home", state: "mounted", opts: "defaults" }
 # - { name: "/scratch", src: "{{ nfs_mount_addr }}:/scratch", dirmode: "1777"}
-
-#Overwite this to true in your playbook's variables or simply include "-e clean_fstab_backups=True" if you want to remove old fstab backup files created by bug #4
-clean_fstab_backups: False

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,2 +1,0 @@
----
-# handlers file for ansible-role-nfs_mount/

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,7 +14,7 @@ galaxy_info:
   # - Apache
   # - CC-BY
   license: MIT
-  min_ansible_version: 2.2
+  min_ansible_version: 2.3
   #
   # Below are all platforms currently available. Just uncomment
   # the ones that apply to your role. If you don't see your 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,67 +1,16 @@
 ---
 # tasks file for ansible-role-nfs_mount/
 
-- name: (DEPRECATED) Creates /home dir (if it doesn't exist)
-  file: 
-     path: /home
-     state: directory
-     mode: 0755
-  when: nfs_mount is defined
-
-- name: (DEPRECATED) Creates /scratch dir (if it doesn't exist)
-  file: 
-     path: "/scratch"
-     state: directory
-     mode: 0755
-  when: nfs_mount is defined
-
-## old method using lineinfile and editing fstab 
-
-- name: (DEPRECATED) lineinfile cleaning previous entries on /etc/fstab
-  lineinfile:
-       backup: no
-       dest: /etc/fstab
-       regexp: ".*/home\b.*$"
-       state: absent
-  when: nfs_mount is defined
-
-- name: (DEPRECATED) lineinfile cleaning previous entries on /etc/fstab
-  lineinfile: 
-       backup: no
-       dest: /etc/fstab
-       regexp: "^{{ nfs_mount_addr }}"
-       state: absent
-  when: nfs_mount is defined
-
-- name: (DEPRECATED) lineinfile populate /etc/fstab file with NFS mount points
-  lineinfile: 
-       dest: /etc/fstab
-       line: "{{ nfs_mount }}" 
-       state: present
-       backup: no
-  when: nfs_mount is defined
-
-- name: (DEPRECATED) lineinfile cleaning blank lines on /etc/fstab
-  lineinfile: 
-       dest: /etc/fstab
-       regexp: "^\\s*$"
-       state: absent
-       backup: no
-  when: nfs_mount is defined
-
-- name: (DEPRECATED) reloading mount points with mount -a
-  command: /usr/bin/mount -a
-  when: nfs_mount is defined
-
-## new method with the mount module
-
 - name: Create directories (if they do not exist) if nfs_mounts is defined
   file: 
      path: "{{ item.name }}"
      state: directory
      mode: "{{ item.dirmode | default ('0755') }}"
+     group: "{{ item.group | default(omit) }}"
+     owner: "{{ item.owner | default(omit) }}"
+     attributes: "{{ item.attributes | default(omit) }}"
   with_items: "{{ nfs_mounts }}"
-  when: nfs_mounts is defined and nfs_mounts.0 != {} and nfs_mount is not defined
+  when: nfs_mounts is defined
 
 - name: add mountpoints if nfs_mounts is defined and nfs_mount is not
   mount:
@@ -71,23 +20,4 @@
         state: "{{ item.state | default('mounted') }}"
         opts: "{{ item.opts | default('defaults') }}"
   with_items: "{{ nfs_mounts }}"
-  when: nfs_mounts is defined and nfs_mounts.0 != {} and nfs_mount is not defined
-
-- name: find backed up fstab files
-  find: 
-      paths: "/etc" 
-      patterns: "fstab.*~"
-  register: nfs_backup_files
-  changed_when: False
-  check_mode: no
-
-- debug:
-     var: nfs_backup_files
-     verbosity: 1
-
-- name: cleaning fstab backup files
-  file: 
-     path: "{{ item.path }}"
-     state: absent
-  with_items: '{{ nfs_backup_files.files }}'
-  when: clean_fstab_backups and nfs_backup_files.matched != 0
+  when: nfs_mounts is defined

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,12 @@
 ---
 # tasks file for ansible-role-nfs_mount/
+- name: Fail if nfs_mount is defined
+  fail: 
+     msg: "nfs_mount is no longer supported. Change configuration to nfs_mounts instead"
+  when: nfs_mount is defined
 
-- name: Create directories (if they do not exist) if nfs_mounts is defined
-  file: 
+- name: Create directories (if they do not exist) from nfs_mounts
+  file:
      path: "{{ item.name }}"
      state: directory
      mode: "{{ item.dirmode | default ('0755') }}"
@@ -14,11 +18,11 @@
     - nfs_mounts is defined
     - item.name is defined
 
-- name: add mountpoints if nfs_mounts is defined and nfs_mount is not
+- name: add mountpoints from nfs_mounts
   mount:
         fstype: "{{ item.fstype | default('nfs4') }}"
-        name: "{{ item.name }}"  
-        src: "{{ item.src }}"  
+        name: "{{ item.name }}"
+        src: "{{ item.src }}"
         state: "{{ item.state | default('mounted') }}"
         opts: "{{ item.opts | default('defaults') }}"
   with_items: "{{ nfs_mounts }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,7 +10,9 @@
      owner: "{{ item.owner | default(omit) }}"
      attributes: "{{ item.attributes | default(omit) }}"
   with_items: "{{ nfs_mounts }}"
-  when: nfs_mounts is defined
+  when:
+    - nfs_mounts is defined
+    - item.name is defined
 
 - name: add mountpoints if nfs_mounts is defined and nfs_mount is not
   mount:
@@ -20,4 +22,7 @@
         state: "{{ item.state | default('mounted') }}"
         opts: "{{ item.opts | default('defaults') }}"
   with_items: "{{ nfs_mounts }}"
-  when: nfs_mounts is defined
+  when:
+    - nfs_mounts is defined
+    - item.name is defined
+    - item.src is defined

--- a/tests/test-in-docker-image.sh
+++ b/tests/test-in-docker-image.sh
@@ -123,9 +123,9 @@ function extra_tests(){
 }
 
 function show_fstab() {
-	echo %%%%% fstab follows
+	echo "TEST: fstab follows"
 	cat /etc/fstab
-	echo %%%%% fstab ends
+	echo "TEST: fstab ends"
 }
 
 set -e

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -2,5 +2,18 @@
 
  - hosts: localhost
    remote_user: root
+   pre_tasks:
+     - name: create a file we will use to back a block device
+       command: dd if=/dev/zero of=/opt/dev0-backstore bs=1M count=100 creates=/opt/dev0-backstore
+     - name: mknod to create /dev/fake-dev0
+       command: mknod /dev/fake-dev0 b 7 200 creates=/dev/fake-dev1
+     - name: losetup to make loop device point to backing file
+       command: losetup /dev/fake-dev0 /opt/dev0-backstore
+     - name: mkfs.ext4 on new device
+       command: mkfs.ext4 /dev/fake-dev0
+   vars:
+     nfs_mounts:
+       - { fstype: "ext4", name: "/mnt", src: "/dev/fake-dev0", state: "mounted", opts: "defaults" }
+
    roles:
      - ansible-role-nfs_mount

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -5,15 +5,16 @@
    pre_tasks:
      - name: create a file we will use to back a block device
        command: dd if=/dev/zero of=/opt/dev0-backstore bs=1M count=100 creates=/opt/dev0-backstore
-     - name: mknod to create /dev/fake-dev0
-       command: mknod /dev/fake-dev0 b 7 200 creates=/dev/fake-dev1
+     - name: mknod to create fake_dev
+       command: "mknod {{ fake_dev }} b 7 200 creates=/dev/fake-dev1"
      - name: losetup to make loop device point to backing file
-       command: losetup /dev/fake-dev0 /opt/dev0-backstore
+       command: "losetup {{ fake_dev }} /opt/dev0-backstore"
      - name: mkfs.ext4 on new device
-       command: mkfs.ext4 /dev/fake-dev0
+       command: "mkfs.ext4 {{ fake_dev }}"
    vars:
+     fake_dev: "/home/fake-dev0"
      nfs_mounts:
-       - { fstype: "ext4", name: "/mnt", src: "/dev/fake-dev0", state: "mounted", opts: "defaults" }
+       - { fstype: "ext4", name: "/mnt", src: "{{ fake_dev }}", state: "mounted", opts: "defaults" }
 
    roles:
      - ansible-role-nfs_mount

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -3,18 +3,15 @@
  - hosts: localhost
    remote_user: root
    pre_tasks:
-     - name: create a file we will use to back a block device
-       command: dd if=/dev/zero of=/opt/dev0-backstore bs=1M count=100 creates=/opt/dev0-backstore
-     - name: mknod to create fake_dev
-       command: "mknod {{ fake_dev }} b 7 200 creates=/dev/fake-dev1"
-     - name: losetup to make loop device point to backing file
-       command: "losetup {{ fake_dev }} /opt/dev0-backstore"
-     - name: mkfs.ext4 on new device
-       command: "mkfs.ext4 {{ fake_dev }}"
+     - name: fetch an iso to mounting with
+       get_url:
+         url: "http://ftp.sh.cvut.cz/slax/Slax-9.x/slax-ipxe.iso"
+         dest: "/tmp/slax-ipxe.iso"
+         mode: 0640
+       
    vars:
-     fake_dev: "/home/fake-dev0"
      nfs_mounts:
-       - { fstype: "ext4", name: "/mnt", src: "{{ fake_dev }}", state: "mounted", opts: "defaults" }
+       - { fstype: "iso9660", name: "/mnt", src: "/tmp/slax-ipxe.iso", state: "mounted", opts: "defaults" }
 
    roles:
      - ansible-role-nfs_mount

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -2,10 +2,5 @@
 
  - hosts: localhost
    remote_user: root
-   pre_tasks:
-     - name: touch a fstab test file
-       file: path="/etc/fstab.2016-10-20@15:21:01~" state=touch
-   vars:
-     - clean_fstab_backups: True
    roles:
      - ansible-role-nfs_mount

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,0 @@
----
-# vars file for ansible-role-nfs_mount/


### PR DESCRIPTION
The "new" method was introduced in #3 - September 2016.
Let's remove the old way completely.

As a bonus we also:
 - skip if name and src are not defined in nfs_mounts
 - mount an iso file during testing.