### PR TITLE
Use of the "nfs4" type in /etc/fstab is deprecated.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ Role Variables
 
 <pre>
 nfs_mounts:
- - { fstype: "nfs4", name: "/home", src: "{{ nfs_mount_addr }}:/home", state: "mounted", opts: "defaults" }
+ - { fstype: "nfs", name: "/home", src: "{{ nfs_mount_addr }}:/home", state: "mounted", opts: "defaults" }
  - { name: "/scratch", src: "{{ nfs_mount_addr }}:/scratch", dirmode: "1777" }
 </pre>
 
-Notice how fstype defaults to "nfs4", state defaults to "mounted" and opts defaults to "defaults".
+Notice how fstype defaults to "nfs", state defaults to "mounted" and opts defaults to "defaults".
 
 Dependencies
 ------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,5 +2,5 @@
 # defaults file for ansible-role-nfs_mount/
 nfs_mounts:
   - {}
-# - { fstype: "nfs4", name: "/home", src: "{{ nfs_mount_addr }}:/home", state: "mounted", opts: "defaults" }
+# - { fstype: "nfs", name: "/home", src: "{{ nfs_mount_addr }}:/home", state: "mounted", opts: "defaults" }
 # - { name: "/scratch", src: "{{ nfs_mount_addr }}:/scratch", dirmode: "1777"}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,7 +20,7 @@
 
 - name: add mountpoints from nfs_mounts
   mount:
-        fstype: "{{ item.fstype | default('nfs4') }}"
+        fstype: "{{ item.fstype | default('nfs') }}"
         name: "{{ item.name }}"
         src: "{{ item.src }}"
         state: "{{ item.state | default('mounted') }}"


### PR DESCRIPTION
Just noticed this from manualpage. As default without fstype specification didn't mount anymore :-(